### PR TITLE
Remove `function SMODS.INIT.Taikomochi()` to fix modicons

### DIFF
--- a/Taikomochi.lua
+++ b/Taikomochi.lua
@@ -13,10 +13,6 @@ SMODS.Atlas { -- modicon by cerloCasa
 	path = 'modicon.png',
 }
 
-function SMODS.INIT.Taikomochi()
-	-- Mod init
-end
-
 -------------------
 -- UI Injections --
 -------------------


### PR DESCRIPTION
**Removes the `SMODS.INIT.Taikomochi()` function to prevent Taikomochi from overwriting other 0.9.8 mods' icons.**

This breaks any "remaining" 0.9.8 compatibility in Taikomochi. This was already nonexistent, since Taikomochi has been using the 1.0.0 API for a while now.

Quick explanation as to why this happens (copied from the [original discord message](https://discord.com/channels/1116389027176787968/1211425207080718416/1283444112996958303)):
All 0.9.8 mods get loaded in "compatibility mode", where `prefix` does not get defined for 0.9.8 mods like it would normally.
Because Taikomochi has the `function SMODS.INIT.Taikomochi()`, it gets loaded in this compatibility mode, even though Taikomochi uses parts of the 1.0.0 API.
This results in the modicon asset getting defined with key `modicon`, when it really should be `taikomochi_modicon`-ish instead. 
When loading all the other mods' icons, Steamodded tries to see if they have a modicon or not, usually done by `[prefix]_modicon`.
Unfortunately, because the 0.9.8 mods do not have a `prefix` defined, Steamodded looks for `modicon` instead. This is where it finds the icon that Taikomochi just defined.
That then results in all the other 0.9.8 mods also having the Taikomochi icon.